### PR TITLE
Fix content length sent from proxy -> conductor

### DIFF
--- a/src/proxy/utils.js
+++ b/src/proxy/utils.js
@@ -263,7 +263,7 @@ export function createProxyOptionsBuffer(
     modifiedBody = JSON.stringify(modifiedBody);
   }
   if (typeof modifiedBody === 'string') {
-    req.headers['content-length'] = modifiedBody.length;
+    req.headers['content-length'] = Buffer.byteLength(modifiedBody, 'utf8');
     // create an array
     modifiedBody = [modifiedBody];
   } else {


### PR DESCRIPTION
It did not produce byte length but char length, which is a problem with
2 byte characters. A single 2 byte char causes the content length to be
  -1 from what would be expected.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>