### PR TITLE
Support creation of multiple schedules for one workflow

### DIFF
--- a/openapi/workflow-manager.json
+++ b/openapi/workflow-manager.json
@@ -1529,6 +1529,18 @@
             "additionalProperties": {
               "type": "object"
             }
+          },
+          "hasSchedule": {
+            "type": "string"
+          },
+          "expectedScheduleName": {
+            "type": "string"
+          },
+          "existingScheduleNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/src/proxy/transformers/schellar.js
+++ b/src/proxy/transformers/schellar.js
@@ -28,7 +28,6 @@ import type {
   TransformerRegistrationFun,
 } from '../../types';
 
-const versionSeparator = ':';
 let schellarTarget: string;
 
 // Used in POST and PUT
@@ -37,13 +36,7 @@ function sanitizeScheduleBefore(
   schedule: ScheduleRequest,
   req: ExpressRequest,
 ): void {
-  const expectedName =
-    schedule.workflowName + versionSeparator + schedule.workflowVersion;
-  if (schedule.name !== expectedName) {
-    console.error('Unexpected schedule name', { schedule, expectedName });
-    throw 'Unexpected schedule name';
-  }
-  if (expectedName.indexOf('/') > -1) {
+  if (schedule.name.indexOf('/') > -1) {
     // guard against https://github.com/flaviostutz/schellar/issues/4
     console.error('Cannot create schedule with name containing "/" character');
     throw 'Cannot create schedule with name containing "/" character';


### PR DESCRIPTION
 - schedule name can be different from the workflow name name and must be unique
 - existing schedules for workflow in /metadata/workflow
 - updated swagger docs