### PR TITLE
Fix task post failing

### DIFF
--- a/src/proxy/transformers/task.js
+++ b/src/proxy/transformers/task.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import { adminAccess } from '../utils.js';
+import {adminAccess, createProxyOptionsBuffer} from '../utils.js';
 import type {
   AfterFun,
   BeforeFun,
@@ -52,7 +52,7 @@ const postTaskBefore: BeforeFun = (identity, req, res, proxyCallback) => {
     return;
   }
 
-  proxyCallback();
+  proxyCallback({ buffer: createProxyOptionsBuffer(req.body, req) });
 };
 
 const ackTaskBefore: BeforeFun = (identity, req, res, proxyCallback) => {


### PR DESCRIPTION
This fixes error on conductor side: "Error
HttpMessageNotReadableException url: '/api/tasks/'"

The request body was not propagated to conductor from proxy.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>