### PR TITLE
Fine tune the HTTP Keep-Alive timeouts (both client and server)

### DIFF
--- a/src/http-server-side.js
+++ b/src/http-server-side.js
@@ -32,6 +32,7 @@ function makeOptions(
     // setting `json: true` would help by automatically converting, but it adds
     // `Accept: application/json` header that triggers conductor's bug #376,
     // see https://github.com/Netflix/conductor/issues/376
+    timeout: process.env.CLIENT_TIMEOUT ?? 15000,
   };
   // If body is empty object, convert it to null.
   // Otherwise the http library will send a request

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,9 @@ const proxyTarget = process.env.PROXY_TARGET || 'http://conductor-server:8080';
 const schellarTarget = process.env.SCHELLAR_TARGET || 'http://schellar:3000';
 const tenantProxyUrl = 'http://localhost:8088/proxy/';
 
+const serverTimeout = process.env.SERVER_TIMEOUT ?? 20000;
+const serverKeepAliveTimeout = process.env.SERVER_KEEP_ALIVE_TIMEOUT ?? 20000;
+
 /*
 TODO: merge conductor proxy with tenant / rbac proxy
 TODO: do not make a real HTTP call between rbac_proxy and proxy (extract the functionality from express server if possible)
@@ -218,7 +221,10 @@ async function init() {
   app.get('/probe/readiness', (req, res) => {
     res.sendStatus(200);
   });
-  app.listen(userFacingPort);
+
+  const server = app.listen(userFacingPort);
+  server.timeout = serverTimeout;
+  server.keepAliveTimeout = serverKeepAliveTimeout;
 }
 
 init();


### PR DESCRIPTION
This PR addresses an issue encountered in a test environment where the customer was launching 10 simultaneous workflows followed by 10 simultaneous "Get Workflow Id" operations, and sometimes it was getting an HTTP 500 error stating there was a TCP RST.
<pre>Error: read ECONNRESET<br> &nbsp; &nbsp;at TCP.onStreamRead (node:internal/stream_base_commons:217:20)</pre>
After checking this with @marosmars, we found out the Node.JS HTTP server had a default timeout of 5 seconds, while the Node.JS HTTP client didn't have a timeout defined, hence why sometimes the client would send a request through a connection that the server was already in the process of closing (race condition), which ultimately caused this issue.

In order to fix it, the client timeout should be less than the server timeout, so the default timeout for the client is now 15 seconds, while the server timeout is 20 seconds, both overridable through new environment variables.
This fix has been validated successfully in the customer's environment.